### PR TITLE
IMPROVED: make table.prolog-answers td cells vertical top aligned 

### DIFF
--- a/web/css/runner.css
+++ b/web/css/runner.css
@@ -168,7 +168,7 @@ pre.msg-error         { color: red; font-weight: bold}
 /* Deal with tabled output */
 
 table.prolog-answers    { width: 100%; }
-table.prolog-answers td { padding: 0px 5px; border: 1px solid #888;}
+table.prolog-answers td { padding: 0px 5px; border: 1px solid #888; vertical-align: top; }
 table.prolog-answers th { padding: 0px 5px; border: 1px solid #888; text-align: center;}
 
 table.prolog-answers tr:nth-child(odd)  { background-color: #eee; }


### PR DESCRIPTION
so you do not need to search for a small data entry when other cells in the same row have are much larger height