### PR TITLE
order libraries roughly by usage frequency and ease of (correct) use

### DIFF
--- a/profiles/30-CLP.pl
+++ b/profiles/30-CLP.pl
@@ -1,9 +1,9 @@
 % Constraint Logic Programming
-:- use_module(library(when)).		% Coroutining
 :- use_module(library(dif)).		% Sound inequality
 :- use_module(library(clpfd)).		% Finite domain constraints
 :- use_module(library(clpb)).		% Boolean constraints
 :- use_module(library(chr)).		% Constraint Handling Rules
+:- use_module(library(when)).		% Coroutining
 
 % Your program goes here
 

--- a/profiles/30-CLP.swinb
+++ b/profiles/30-CLP.swinb
@@ -5,8 +5,7 @@
 
 This skeleton notebook pre-loads SWI-Prolog's libraries for _constraint logic programming_.  The libraries are:
 
-  - library(when) and library(dif) provide general _coroutining_
-    facilities. [Documentation](http://www.swi-prolog.org/pldoc/man?section=extvar)
+  - library(dif) provides sound term inequality. [Documentation](http://www.swi-prolog.org/pldoc/doc_for?object=dif/2)
   - library(clpfd) reasons about variables with a _finite domain_
     (a set of integers).  [Documentation](http://www.swi-prolog.org/pldoc/man?section=clpfd)
   - library(clpb) reasons about boolean variables (0 and 1).
@@ -15,14 +14,16 @@ This skeleton notebook pre-loads SWI-Prolog's libraries for _constraint logic pr
     constraint solvers and is particularly useful for providing application-specific constraints.
     It has been used in many kinds of applications, like scheduling, model checking, abduction,
     and type checking, among many others.  [Documentation](http://www.swi-prolog.org/pldoc/man?section=chr)
+  - library(when) provides lower-level _coroutining_
+    facilities. [Documentation](http://www.swi-prolog.org/pldoc/doc_for?object=when/2)
 </div>
 
 <div class="nb-cell program" data-background="true" data-singleline="true">
-:- use_module(library(when)).		% Coroutining
 :- use_module(library(dif)).		% Sound inequality
 :- use_module(library(clpfd)).		% Finite domain constraints
 :- use_module(library(clpb)).		% Boolean constraints
 :- use_module(library(chr)).		% Constraint Handling Rules
+:- use_module(library(when)).		% Coroutining
 </div>
 
 <div class="nb-cell program">


### PR DESCRIPTION
In particular, `when/2` is not necessary for beginners. Start with `dif/2`, CLP(FD) etc.