### PR TITLE
FIXED: Prevent incorrect rendering for queries like Qs = [_,_], n_que…

### DIFF
--- a/lib/render/chess.pl
+++ b/lib/render/chess.pl
@@ -70,6 +70,7 @@ term_rendering(Term, _Vars, _Options) -->
 
 is_nqueens(Term) :-
 	is_list(Term),
+	maplist(integer, Term),
 	length(Term, N),
 	numlist(1, N, All),
 	sort(Term, All).


### PR DESCRIPTION
…ens(_, Qs). Ulrich Neumerkel.