### PR TITLE
ADDED: New renderer for CLP(B)'s Binary Decision Diagrams: bdd.

### DIFF
--- a/examples/render_XXX.swinb
+++ b/examples/render_XXX.swinb
@@ -5,7 +5,7 @@
 
 #### Synopsis
 
-    :- use_renderer(XXX).
+    :- use_rendering(XXX).
 
 #### Options supported
 

--- a/examples/render_bdd.swinb
+++ b/examples/render_bdd.swinb
@@ -69,4 +69,19 @@ length(Vs, 20), sat(card([2],Vs)),
 copy_term(Vs, Vs, [BDD]), maplist(del_attrs, Vs).
 </div>
 
+<div class="nb-cell markdown">
+
+Building on this idea, the third example shows that you can impose an
+arbitrary *order* on the variables in the&nbsp;BDD by first stating a
+tautology like `+[1,V1,V2,...]`. This orders the variables in the same
+way they appear in this list.
+
+</div>
+
+<div class="nb-cell query">
+sat(+[1,Z,Y,X]), sat(X+Y+Z),
+Vs = [X,Y,Z],
+copy_term(Vs, Vs, [BDD]), maplist(del_attrs, Vs).
+</div>
+
 </div>

--- a/examples/render_bdd.swinb
+++ b/examples/render_bdd.swinb
@@ -13,10 +13,10 @@ None
 
 #### Reconised terms
 
-The `bdd` renderer recognises residual goals of `library(clpb)` and
-draws them as Binary Decision Diagrams&nbsp;(BDDs). Both kinds of
-residual goals that `library(bdd)` can&nbsp;emit are supported by this
-renderer:
+The `bdd` renderer recognises CLP(B) residual goals of `library(clpb)`
+and draws them as Binary Decision Diagrams&nbsp;(BDDs). Both kinds of
+residual goals that `library(clpb)` can&nbsp;emit are supported by
+this&nbsp;renderer:
 
 By default, `library(clpb)` emits `sat/1` residual goals. These are
 first translated to&nbsp;BDDs by this renderer.
@@ -28,10 +28,14 @@ residual&nbsp;goals. Currently, setting this flag does not affect the
 SWISH&nbsp;toplevel, so you also need to use&nbsp;`del_attrs/1`
 to&nbsp;avoid the costly projection. See below for an example.
 
+In both cases, the graphviz renderer is used for the final output.
 </div>
 
 <div class="nb-cell markdown">
 ## Examples
+
+The first example simply enables the `bdd` renderer and posts a CLP(B)
+query to show the residual goal as a BDD.
 
 </div>
 

--- a/examples/render_bdd.swinb
+++ b/examples/render_bdd.swinb
@@ -1,0 +1,68 @@
+<div class="notebook">
+
+<div class="nb-cell markdown">
+# The BDD renderer
+
+#### Synopsis
+
+    :- use_rendering(bdd).
+
+#### Options supported
+
+None
+
+#### Reconised terms
+
+The `bdd` renderer recognises residual goals of `library(clpb)` and
+draws them as Binary Decision Diagrams&nbsp;(BDDs). Both kinds of
+residual goals that `library(bdd)` can&nbsp;emit are supported by this
+renderer:
+
+By default, `library(clpb)` emits `sat/1` residual goals. These are
+first translated to&nbsp;BDDs by this renderer.
+
+In cases where the projection to `sat/1` goals is too costly, you can
+set the Prolog flag `clpb_residuals` to&nbsp;`bdd` yourself, and use
+`copy_term/3` to obtain a BDD&nbsp;representation of the
+residual&nbsp;goals. Currently, setting this flag does not affect the
+SWISH&nbsp;toplevel, so you also need to use&nbsp;`del_attrs/1`
+to&nbsp;avoid the costly projection. See below for an example.
+
+</div>
+
+<div class="nb-cell markdown">
+## Examples
+
+</div>
+
+<div class="nb-cell program">
+:- use_rendering(bdd).
+:- use_module(library(clpb)).
+</div>
+
+<div class="nb-cell query">
+sat(X+Y).
+</div>
+
+<div class="nb-cell markdown">
+
+The second example sets `clpb_residuals` to&nbsp;`bdd` in order to
+prevent the costly projection to `sat/1` goals. Note that this also
+requires the use of&nbsp;`del_attrs/1` and&mdash;since renderers are
+not invoked on subterms&mdash;introducing a new variable for the
+single residual goal that represents the&nbsp;BDD.
+
+</div>
+
+<div class="nb-cell program">
+:- use_rendering(bdd).
+:- use_module(library(clpb)).
+:- set_prolog_flag(clpb_residuals, bdd).
+</div>
+
+<div class="nb-cell query">
+length(Vs, 20), sat(card([2],Vs)),
+copy_term(Vs, Vs, [BDD]), maplist(del_attrs, Vs).
+</div>
+
+</div>

--- a/examples/render_chess.swinb
+++ b/examples/render_chess.swinb
@@ -5,7 +5,7 @@
 
 #### Synopsis
 
-    :- use_renderer(chess).
+    :- use_rendering(chess).
 
 #### Options supported
 

--- a/examples/render_codes.swinb
+++ b/examples/render_codes.swinb
@@ -5,8 +5,8 @@
 
 #### Synopsis
 
-    :- use_renderer(codes).
-    :- use_renderer(codes, Options).
+    :- use_rendering(codes).
+    :- use_rendering(codes, Options).
 
 #### Options supported
 

--- a/examples/render_sudoku.swinb
+++ b/examples/render_sudoku.swinb
@@ -5,7 +5,7 @@
 
 #### Synopsis
 
-    :- use_renderer(sudoku).
+    :- use_rendering(sudoku).
 
 #### Options supported
 

--- a/examples/render_svgtree.swinb
+++ b/examples/render_svgtree.swinb
@@ -5,8 +5,8 @@
 
 #### Synopsis
 
-    :- use_renderer(svgtree).
-    :- use_renderer(svgtree, Options).
+    :- use_rendering(svgtree).
+    :- use_rendering(svgtree, Options).
 
 #### Options supported
 

--- a/examples/render_table.swinb
+++ b/examples/render_table.swinb
@@ -7,8 +7,8 @@ This plugin requires a two-deminsional array of terms.
 
 #### Synopsis
 
-    :- use_renderer(table).
-    :- use_renderer(table, Options).
+    :- use_rendering(table).
+    :- use_rendering(table, Options).
     
 #### Options supported
    

--- a/examples/rendering.swinb
+++ b/examples/rendering.swinb
@@ -37,6 +37,7 @@ The following rendering plugins are currently supported.  Please visit the linke
       etc.) using [C3.js](http://www.c3js.org)
     - [codes](example/render_codes.swinb) renders lists of code-points as text.
   - Domain specific renderers
+    - [bdd](example/render_bdd.swinb) renders CLP(B) residual goals as Binary Decision Diagrams (BDDs)
     - [chess](example/render_chess.swinb) renders chess positions (currently only
       N-queen boards).
     - [sudoku](example/render_sudoku.swinb) renders sudoku puzzles.

--- a/lib/render/bdd.pl
+++ b/lib/render/bdd.pl
@@ -1,0 +1,115 @@
+/*  Part of SWI-Prolog
+
+    Author:        Markus Triska
+    E-mail:        triska@metalevel.at
+    WWW:           http://www.swi-prolog.org
+    Copyright (C): 2016 Markus Triska
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(swish_render_bdd,
+          [ term_rendering//3                   % +Term, +Vars, +Options
+          ]).
+:- use_module('../render').
+:- use_module(graphviz, []).
+:- use_module(library(clpb)).
+:- use_module(library(varnumbers)).
+
+:- register_renderer(bdd, "Render BDDs corresponding to CLP(B) constraints").
+
+/** <module> Render Binary Decision Diagrams (BDDs)
+
+This renderer draws Binary Decision Diagrams (BDDs) that express
+CLP(B) constraints.
+
+Both kinds of residual goals that `library(bdd)` can emit are
+supported by this renderer: By default, `library(clpb)` emits `sat/1`
+residual goals. These are first translated to BDDs by reposting the
+goals while temporarily setting `clpb_residuals` to `bdd`. The
+translation of such BDDs to `dot/1` terms is straight-forward.
+Alternatively, you can set `clpb_residuals` to `bdd` yourself. In that
+case, residual goals are directly emitted as BDDs and are again
+translated to `dot/1` terms by this renderer.
+
+In both cases, the graphviz renderer is used for the final output.
+
+*/
+
+%%      term_rendering(+Term, +Vars, +Options)//
+%
+%       Renders BDDs as emitted by library(clpb).
+
+term_rendering(Goal, Vars, Options) -->
+        (   { Goal = clpb:'$clpb_bdd'(Ns),
+              is_list(Ns) } -> []
+        ;   { Goal = sat(Sat0) } ->
+            { current_prolog_flag(clpb_residuals, OldFlag),
+              varnumbers_names(Sat0, Sat, VNames),
+              term_variables(Sat, Vs),
+              setup_call_cleanup(set_prolog_flag(clpb_residuals, bdd),
+                                 catch((sat(Sat),
+                                        copy_term(Vs, Vs, [clpb:'$clpb_bdd'(Ns)]),
+                                        % reset all attributes
+                                        maplist(del_attrs, Vs),
+                                        throw(nodes(Vs,Ns))),
+                                       % Vs recreate the bindings in nodes Ns
+                                       nodes(Vs,Ns),
+                                       true),
+                                 set_prolog_flag(clpb_residuals, OldFlag)),
+              % for displaying the labels, unify each variable with its name
+              maplist(eq, VNames) }
+        ),
+        { nodes_dot_digraph(Ns, Dot) },
+        swish_render_graphviz:term_rendering(Dot, Vars, Options).
+
+eq(Name=Var) :- Name = Var.
+
+nodes_dot_digraph(Nodes, dot(digraph(Stmts))) :-
+        maplist(node_then_else, Nodes, Thens, Elses),
+        phrase((nodes_labels(Nodes),
+                [node(false, [fontname='Palatino-Bold']),
+                 node(true, [fontname='Palatino-Bold'])],
+                [edge([style='filled'])],
+                list(Thens),
+                [edge([style='dotted'])],
+                list(Elses)), Stmts).
+
+nodes_labels([]) --> [].
+nodes_labels([node(N)-(v(Var,_) -> _ ; _)|Nodes]) -->
+        [node(N, [label=Var])],
+        nodes_labels(Nodes).
+
+node_then_else(Node-(_->Then0;Else0), (ID->Then), (ID->Else)) :-
+        maplist(node_id, [Node,Then0,Else0], [ID,Then,Else]).
+
+node_id(node(N), N).
+node_id(true, true).
+node_id(false, false).
+
+list([]) --> [].
+list([L|Ls]) --> [L], list(Ls).

--- a/swish.pl
+++ b/swish.pl
@@ -180,3 +180,4 @@ pengines:prepare_module(Module, swish, _Options) :-
 :- use_module(swish(lib/render/graphviz), []).
 :- use_module(swish(lib/render/c3),	  []).
 :- use_module(swish(lib/render/url),	  []).
+:- use_module(swish(lib/render/bdd),	  []).


### PR DESCRIPTION
You can try it with:

    :- use_rendering(bdd).

and then querying for example:

    ?- sat(X+Y).

Note though that in more complex cases,

    :- set_prolog_flag(clpb_residuals, bdd).

should be made to work too. See #27 for the discussion, and #25 for a workaround.