### PR TITLE
added loading of lazy_list module

### DIFF
--- a/lib/highlight.pl
+++ b/lib/highlight.pl
@@ -48,6 +48,7 @@
 :- use_module(library(prolog_xref)).
 :- use_module(library(memfile)).
 :- use_module(library(prolog_colour)).
+:- use_module(library(lazy_lists)).
 :- if(exists_source(library(helpidx))).
 :- use_module(library(helpidx), [predicate/5]).
 :- endif.


### PR DESCRIPTION
I was getting this error
?- ERROR: /usr/local/Cellar/swi-prolog/HEAD-d543c8b_2/libexec/lib/swipl-7.5.2/library/lazy_lists.pl:36:
	Domain error: `module_file' expected, found `'/usr/local/Cellar/swi-prolog/HEAD-d543c8b_2/libexec/lib/swipl-7.5.2/library/lazy_lists.pl''

and

Internal server error

Undefined procedure: swish_highlight:lazy_list/2

SWI-Prolog httpd at Fabrizios-MacBook-Pro.local

in the browser