### PR TITLE
Update of http_version.pl

### DIFF
--- a/lib/http_version.pl
+++ b/lib/http_version.pl
@@ -105,7 +105,7 @@ changes(Commit, Show, Changes) :-
     (   nonvar(Commit)
     ->  atom_concat(Commit, '..', Revisions),
         Options = [ revisions(Revisions) ]
-    ;   Options = [ limit(1) ]
+    ;   Options = []
     ),
     git_shortlog(Dir, ShortLog0, Options),
     (   Show == tagged


### PR DESCRIPTION
This is because otherwise a different commit is save to localStorage in version.js when saveCheckpoint is called the first time and when clicking on new. In the first case, changes is asked without parameters, in the latter, with the stored commit. If the last commit is not tagged, in the first case it is returned, while in latter case the latest tagged commit is returned. This causes a wrong recognition of changes