### PR TITLE
Change github urls to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "sparkline": "gwatts/jquery.sparkline#*",
     "svg-pan-zoom": "ariutta/svg-pan-zoom#*",
     "tagmanager": "max-favilli/tagmanager#*",
-    "typeahead.js": "git://github.com/twitter/typeahead.js.git#master",
-    "printthis": "git://github.com/jasonday/printThis.git#master"
+    "typeahead.js": "https://github.com/twitter/typeahead.js.git#master",
+    "printthis": "https://github.com/jasonday/printThis.git#master"
   },
   "engines": {
     "yarn": ">= 1.0.0"


### PR DESCRIPTION
When I try to build swish locally it fails on `yarn` with
```
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/jasonday/printThis.git
Directory: /home/ruslan/code/swish
Output:
fatal: unable to connect to github.com:
github.com[0: 20.205.243.166]: errno=Connection timed out
```
Can be probably related to
https://github.blog/2021-09-01-improving-git-protocol-security-github/

> No more unauthenticated Git
> On the Git protocol side, unencrypted git:// offers no integrity or authentication, making it subject to tampering. We expect very few people are still using this protocol, especially given that you can’t push (it’s read-only on GitHub). We’ll be disabling support for this protocol.

After I changed urls to https locally `yarn` succeeds in 25s.