### PR TITLE
Improves the Help web pages

### DIFF
--- a/web/help/about.html
+++ b/web/help/about.html
@@ -64,7 +64,7 @@ excercises from within your browser.  Peter Flach prepared his book
 <p>
 The <span style="color:darkblue">SWI</span><span
 style="color:maroon">SH</span> source is available from <a
-href="http://github.com/SWI-Prolog/swish.git">Github</a>. It is under
+href="http://github.com/SWI-Prolog/swish.git">GitHub</a>. It is under
 heavy development and often requires SWI-Prolog 7 installed from the
 latest <a href="http://github.com/SWI-Prolog/swipl-devel.git">GIT</a>.
 We also provide a <a href="https://hub.docker.com/r/swipl/swish/">Docker image</a>.

--- a/web/help/editor.html
+++ b/web/help/editor.html
@@ -23,14 +23,14 @@ the SWISH project.
 We load the default CodeMirror plugin for find and replace.
 The keybindings are:</p>
 <dl class="help-editor">
-  <dt>Ctrl-F / Cmd-F</dt><dd>Start searching</dd>
-  <dt>Ctrl-G / Cmd-G</dt><dd>Find next</dd>
-  <dt>Shift-Ctrl-G / Shift-Cmd-G</dt><dd>Find previous</dd>
-  <dt>Shift-Ctrl-F / Cmd-Option-F</dt><dd>Replace</dd>
-  <dt>Shift-Ctrl-R / Shift-Cmd-Option-F</dt><dd>Replace all</dd>
-  <dt>Alt-F</dt><dd>Persistent search (dialog doesn't autoclose,
-  enter to find next, Shift-Enter to find previous)</dd>
-  <dt>Alt-G</dt><dd>Jump to line</dd>
+  <dt> <kbd>Ctrl</kbd> + <kbd>F</kbd> / <kbd>Command ⌘</kbd> + <kbd>F</kbd></dt><dd>Start searching</dd>
+  <dt> <kbd>Ctrl</kbd> + <kbd>G</kbd> / <kbd>Command ⌘</kbd> + <kbd>G</kbd></dt><dd>Find next</dd>
+  <dt> <kbd>Shift ⇧</kbd> + <kbd>Ctrl</kbd> + <kbd>G</kbd> / <kbd>Shift ⇧</kbd> + <kbd>Command ⌘</kbd> + <kbd>G</kbd></dt><dd>Find previous</dd>
+  <dt><kbd>Shift ⇧</kbd> + <kbd>Ctrl</kbd> + <kbd>F</kbd> / <kbd>Command ⌘</kbd> + <kbd>Option ⌥</kbd> + <kbd>F</kbd></dt><dd>Replace</dd>
+  <dt><kbd>Shift ⇧</kbd> + <kbd>Ctrl</kbd> + <kbd>R</kbd> / <kbd>Shift ⇧</kbd> + <kbd>Command ⌘</kbd> + <kbd>Option ⌥</kbd> + <kbd>F</kbd></dt><dd>Replace all</dd>
+  <dt> <kbd>Alt</kbd> + <kbd>F</kbd></dt><dd>Persistent search (dialog doesn't autoclose,
+  enter to find next, <kbd>Shift ⇧</kbd> + <kbd>Enter ↵</kbd> to find previous)</dd>
+  <dt><kbd>Alt</kbd> + <kbd>G</kbd></dt><dd>Jump to line</dd>
 </dl>
 
 <h2>Navigating</h2>

--- a/web/help/help.html
+++ b/web/help/help.html
@@ -65,7 +65,7 @@ in the next.
 
 <p class="note">
 <span class="glyphicon glyphicon-hand-right"></span> Use
-<strong>Ctrl-Enter</strong> to insert a newline in a complete query
+<strong> <kbd>Ctrl</kbd> + <kbd>Enter ↵</kbd></strong> to insert a newline in a complete query
 
 <h2 id="help-examples">Embedding examples in the program text</h2>
 <p>

--- a/web/help/help.html
+++ b/web/help/help.html
@@ -202,7 +202,8 @@ X = 2
 <h2 id="help-preload">Preload SWISH with data</h2>
 <p>
 You can make <span style="color:darkblue">SWI</span><span style="color:maroon">SH</span>
-start with a loaded program using the URL <code>http://swish.swi-prolog.org/</code> and
+start with a loaded program using the URL <code><a href="http://swish.swi-prolog.org" style="color: inherit;
+  text-decoration: none;">http://swish.swi-prolog.org/</a></code> and
 providing the parameters below.  The URL accepts both `GET` and `POST` requests.
 
   <dl class="dl-horizontal">

--- a/web/help/runner.html
+++ b/web/help/runner.html
@@ -32,11 +32,11 @@ table.runner-states tr.group th {
 <h2>Keyboard shortcuts</h2>
 
   <table class="runner-states">
-  <tr><th>";", &lt;space&gt;</th><td>Next</td>
-  <tr><th>".", &lt;Enter&gt;</th><td>Stop</td>
-  <tr><th>"a", &lt;Esc&gt;</th><td>Stop or abort</td>
-  <tr><th>&lt;Del&gt;</th><td>Close</td>
-  <tr><th>&lt;F1&gt;</th><td>Help (this page)</td>
+  <tr><th><kbd>;</kbd> + <kbd>space</kbd></th><td>Next</td>
+  <tr><th> <kbd>.</kbd> + <kbd>Enter ↵</kbd></th><td>Stop</td>
+  <tr><th> <kbd>a</kbd> + <kbd>Esc</kbd></th><td>Stop or abort</td>
+  <tr><th><kbd>Del</kbd></th><td>Close</td>
+  <tr><th><kbd>F1</kbd></th><td>Help (this page)</td>
   </table>
 
 <h2>Running states</h2>


### PR DESCRIPTION
1. Adds `<kbd>` tag for all the keyboard shortcuts (i.e. <kbd>Command ⌘</kbd>, <kbd>Option ⌥</kbd>, <kbd>Shift ⇧</kbd>, etc.)
2. Adds hyperlinks where possible
3. Minor fixes in the Help menu