### PR TITLE
Update config-available for clpBNR v0.12.0

### DIFF
--- a/config-available/clpBNR.pl
+++ b/config-available/clpBNR.pl
@@ -1,6 +1,8 @@
 :- module(swish_config_clpBNR, []).
 
 :- use_module(library(clpBNR)).
+:- use_module(library(clpBNR_toolkit)).
+:- use_module(library(clpBNR_search)).
 
 :- multifile user:file_search_path/2.
 


### PR DESCRIPTION
Add `clpBNR_toolkit` and `clpBNR_search`  to preload on SWISH (now req'd for sandboxing). This should be done as part of any SWISH build incorporating the  `clpBNR` v0.12.0.

`clpBNR` v0.12.0 includes:
a) new module `clpBNR_search` which is a version of ECLIPSe search libraries(e.g., `fd_search`) for `clpBNR` on SWI-Prolog.
b) additional predicates in module `clpBNR_toolkit` supporting numerical integration.

Both modules require the addition of sandboxing rules which, I think, dictates that they must be pre-loaded on SWISH. (clpBNR_toolkit could be used previously without preloading because no `sandbox` predicates were required.)

I've tested the above on a local SWISH server but can retest on a non-production server is desired.

A "process" question: The version of `clpBNR` (v0.11.7b) currently running on SWISH is several releases old. Is there something I need to do on producing a new version of `clpBNR` to trigger its inclusion in the next SWISH build? Or can something be done to the SWISH "make" scripts, e.g., `pack_upgrade(clpBNR)` so this happens automatically? If so will this also include the appropriate copy of the clpBNR quickstart notebook from the Git repo to examples?

Off topic question: Getting the version of available packs on SWISH is a bit problematical because `pack-info` (and related) are sandboxed on SWISH. I've added clpBNR version to the version info (using the documented hook) but maybe something from the pack manager could be white-listed so this wouldn't be necessary.