### PR TITLE
Add a Table of Content modal dialog to swish notebook

### DIFF
--- a/web/js/links.js
+++ b/web/js/links.js
@@ -199,6 +199,14 @@ define(["jquery", "config", "modal"],
 	    ev.preventDefault();
 	    modal.animate({scrollTop: target.position().top}, 2000);
 	  }
+	} else if ( href.startsWith("#") && $(ev.target).closest(".notebook").length > 0 ) {
+	  var id = href.substring(1);
+	  var target = document.getElementById(id);
+	  if ( target ) {
+	    target.scrollIntoView({behavior: "smooth"});
+	    done = true;
+	    ev.preventDefault();
+	  }
 	}
 
 	if ( !done ) {


### PR DESCRIPTION
Hello,
This is the PR for the Table of Content modal dialog shown in this [discourse discussion](https://swi-prolog.discourse.group/t/table-of-contents-in-swish-notebook/9330/3?u=kwon-young).

In addition, I have also integrated the fix for `#ref` for internal notebook links, so that the user can build a TOC cell manually if he wants.
I have mentioned in the discourse message that I used an llm to help me code this features, but I have then put time into really understanding the modified code in the PR, as well as trying to reduce the modified code to a maximum.